### PR TITLE
build: bump compileSdk to 37

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "eu.hxreborn.cleanshare"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "eu.hxreborn.cleanshare"


### PR DESCRIPTION
Required after Compose BOM 2026.05.01 — compose 1.12.0-alpha03 requires compileSdk >= 37.